### PR TITLE
move to using absolute imports (for python3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.egg-info
 .cache/
 glove.6B.zip
 glove.6B/glove.6B.100d.txt
@@ -6,3 +7,4 @@ glove.6B/glove.6B.200d.txt
 glove.6B/glove.6B.300d.txt
 glove.6B/glove.6B.50d.txt
 env/
+.python-version

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The evaluation scipt reports the results on the test data set of the SemEval2016
 the resport run the following commands:
 ```bash
 source env/bin/activate
-python paradox/benchmark.py
+python benchmark.py
 ```
 
 ## Citation

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,9 +1,9 @@
-from metrics import pearson, mse
-from pipeline import pipeline
-import k_neighbors_regressor
+from paradox.metrics import pearson, mse
+from paradox.pipeline import pipeline
+from paradox import k_neighbors_regressor
 import numpy as np
-import similarity
-import parser
+from paradox import similarity
+from paradox import parser
 
 
 def report(correlations, errors, y_pred_fold):

--- a/paradox/__init__.py
+++ b/paradox/__init__.py
@@ -1,22 +1,5 @@
-from paradox.logstash_formatter import LogstashFormatterV2
-import logging
+import os
 
-
-def config_logger(log_level=logging.INFO):
-    """Configures the logger
-    """
-    logger = logging.getLogger()
-    logger.setLevel(log_level)
-
-    # Disables the logs from the requests library
-    requests_log = logging.getLogger("requests")
-    requests_log.addHandler(logging.NullHandler())
-    requests_log.propagate = False
-
-    # Sets formatter to the logstash formatter
-    handler = logging.StreamHandler()
-    formatter = LogstashFormatterV2()
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-config_logger()
+PARADOX_FOLDER = os.path.dirname(os.path.abspath(__file__))
+GLOVE_FOLDER = os.path.join(os.path.dirname(PARADOX_FOLDER), 'glove.6B')
+CORPUS_FOLDER = os.path.join(os.path.dirname(PARADOX_FOLDER), 'corpus')

--- a/paradox/glove.py
+++ b/paradox/glove.py
@@ -1,15 +1,17 @@
+import os
 import io
 
+from paradox import GLOVE_FOLDER
 
 def map_dim_to_file(dim=200):
     if dim == 50:
-        return "glove.6B/glove.6B.50d.txt"
+        return os.path.join(GLOVE_FOLDER, "glove.6B.50d.txt")
     elif dim == 100:
-        return "glove.6B/glove.6B.100d.txt"
+        return os.path.join(GLOVE_FOLDER, "glove.6B.100d.txt")
     elif dim == 200:
-        return "glove.6B/glove.6B.200d.txt"
+        return os.path.join(GLOVE_FOLDER, "glove.6B.200d.txt")
     elif dim == 300:
-        return "glove.6B/glove.6B.300d.txt"
+        return os.path.join(GLOVE_FOLDER, "glove.6B.300d.txt")
     else:
         return ValueError("Dimension {} is not supported!".format(dim))
 

--- a/paradox/parser.py
+++ b/paradox/parser.py
@@ -2,8 +2,9 @@ import logging
 import json
 import os
 
+from paradox import CORPUS_FOLDER
 
-def parse(mapping="corpus/mapping.json", mode='train',
+def parse(mapping=os.path.join(CORPUS_FOLDER, "mapping.json"), mode='train',
           categories=['question-question']):
     mapping = json.loads(open(mapping).read())[mode]
     pairs = []
@@ -19,10 +20,10 @@ def parse(mapping="corpus/mapping.json", mode='train',
 
 def _parse(rawfile_path=None, gsfile_path=None):
     pairs = []
-    with open(os.path.join("corpus", rawfile_path)) as raw_file:
+    with open(os.path.join(CORPUS_FOLDER, rawfile_path)) as raw_file:
         logging.info("Parsing raw file: {}".format(rawfile_path))
         raw_lines = raw_file.readlines()
-        with open(os.path.join("corpus", gsfile_path)) as gs_file:
+        with open(os.path.join(CORPUS_FOLDER, gsfile_path)) as gs_file:
             logging.info("Parsing gs file: {}".format(gsfile_path))
             gs_lines = gs_file.readlines()
             for raw_line, gs_line in zip(raw_lines, gs_lines):

--- a/paradox/similarity.py
+++ b/paradox/similarity.py
@@ -2,8 +2,8 @@ from scipy.spatial.distance import cosine
 from sklearn.pipeline import Pipeline
 from sklearn.base import BaseEstimator
 from pythonrouge import pythonrouge
-from preprocessor import preprocess
-from glove import Glove
+from .preprocessor import preprocess
+from .glove import Glove
 import numpy as np
 
 glove = Glove.load(dim=200)


### PR DESCRIPTION
- move benchmark.py outside of the paradox folder (it would require running as `python -m paradox.benchmark` if you wanted to keep it in the folder)
- use computed relative paths `GLOVE_FOLDER` and `CORPUS_FOLDER` starting from the root `paradox` folder (for being able to import paradox in another project where paths relative to CWD don't work)

ref on need for abs imports: https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html#absolute-vs-relative-import