### PR TITLE
add verbose mode for similarity transformer

### DIFF
--- a/paradox/similarity.py
+++ b/paradox/similarity.py
@@ -41,8 +41,8 @@ def similarity(text1, text2, levels=['surface', 'context']):
     return sims
 
 
-def build(levels=['surface', 'context']):
-    pipeline = Pipeline([('transformer', Similarity(levels=levels))])
+def build(levels=['surface', 'context'], verbose=False):
+    pipeline = Pipeline([('transformer', Similarity(levels=levels, verbose=verbose))])
     return ('similarity', pipeline)
 
 
@@ -52,15 +52,24 @@ def param_grid():
 
 
 class Similarity(BaseEstimator):
-    def __init__(self, levels=['surface']):
+    def __init__(self, levels=['surface'], verbose=False):
         self.levels = levels
+        self.verbose = verbose
 
     def fit(self, X, y):
         return self
 
     def transform(self, X):
         a = []
-        for x in X:
+
+        tqdm = lambda x: x
+        if self.verbose:
+            try:
+                from tqdm import tqdm
+            except ImportError:
+                pass 
+
+        for x in tqdm(X):
             a.append(self._transform(x))
         return a
 


### PR DESCRIPTION
after #32 is merged, this line in benchmark.py needs to change from:

```
transformer = similarity.build()
```

to

```
transformer = similarity.build(verbose=True)
```

in order to activate the similarity transformer. I did not make this change yet to prevent merge conflicts.

I tested these three PRs by running:

```
git merge fork/rebuild-wordnet-exceptions fork/absolute-imports fork/verbose-mode
# activate verbose mode by editing benchmark.py as shown above
python benchmark.py
```

<img width="1280" alt="screen shot 2018-08-14 at 8 57 21 am" src="https://user-images.githubusercontent.com/2790092/44092995-162a9780-9fa0-11e8-815c-0e5511b0f4a1.png">

🎉